### PR TITLE
Fix to work with API Key rather than oAuth; add support for Photo Sizes

### DIFF
--- a/Open.Flickr/FlickrClient.cs
+++ b/Open.Flickr/FlickrClient.cs
@@ -4,6 +4,7 @@ using Open.OAuth;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
@@ -91,12 +92,39 @@ namespace Open.Flickr
             var response = await client.GetAsync(uri, cancellationToken);
             if (response.IsSuccessStatusCode)
             {
-                return (await response.Content.ReadJsonAsync<PhotoResult>()).Photo;
+                PhotoResult result = await response.Content.ReadJsonAsync<PhotoResult>();
+
+                if (result.Stat == "ok")
+                {
+                    return result.Photo;
+                }
             }
-            else
+
+            throw await ProcessException(response.Content);
+        }
+
+        public async Task<PhotoSizeCollection> GetPhotoSizesAsync(string photoId, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            var parameters = new Dictionary<string, string>
             {
-                throw await ProcessException(response.Content);
+                { "photo_id", photoId },
+            };
+
+            var uri = BuildApiUri("flickr.photos.getSizes", parameters: parameters);
+            var client = CreateClient();
+            var response = await client.GetAsync(uri, cancellationToken);
+
+            if (response.IsSuccessStatusCode)
+            {
+                PhotoSizeResult result = await response.Content.ReadJsonAsync<PhotoSizeResult>();
+
+                if (result.Stat == "ok")
+                {
+                    return result.Sizes;
+                }
             }
+
+            throw await ProcessException(response.Content);
         }
 
         public async Task<Photosets> GetPhotosetsAsync(int page, int perPage, CancellationToken cancellationToken = default(CancellationToken))
@@ -518,7 +546,16 @@ namespace Open.Flickr
             parameters.Add("format", "json");
             parameters.Add("method", method);
             parameters.Add("nojsoncallback", "1");
-            return new Uri(OAuthClient.CreateOAuthUrl(_apiServiceUri, _oauthConsumerKey, _oauthConsumerKeySecret, _accessToken, _accessTokenSecret, mode: mode, parameters: parameters));
+
+            if (!string.IsNullOrEmpty(_oauthConsumerKey))
+            {
+                return new Uri(OAuthClient.CreateOAuthUrl(_apiServiceUri, _oauthConsumerKey, _oauthConsumerKeySecret, _accessToken, _accessTokenSecret, mode: mode, parameters: parameters));
+            }
+
+            parameters.Add("api_key", _accessToken);
+            List<string> keys = parameters.Select(p => $"{p.Key}={p.Value}").ToList();
+
+            return new Uri($"{_apiServiceUri}?{string.Join("&", keys)}");
         }
 
         private static HttpClient CreateClient()
@@ -530,7 +567,7 @@ namespace Open.Flickr
 
         private async Task<Exception> ProcessException(HttpContent content)
         {
-            return new Exception(await content.ReadAsStringAsync());
+            return new FlickrException(0, await content.ReadAsStringAsync());
         }
 
         #endregion

--- a/Open.Flickr/FlickrClient.cs
+++ b/Open.Flickr/FlickrClient.cs
@@ -25,11 +25,28 @@ namespace Open.Flickr
         private string _oauthConsumerKeySecret;
         private string _accessToken;
         private string _accessTokenSecret;
+        private string _apiKey;
 
         #endregion
 
         #region ** initialization
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlickrClient"/> class.
+        /// </summary>
+        /// <param name="apiKey">The API key used to authenticate requests.</param>
+        public FlickrClient(string apiKey)
+        {
+            _apiKey = apiKey;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FlickrClient"/> class.
+        /// </summary>
+        /// <param name="oauthConsumerKey">The oauth consumer key.</param>
+        /// <param name="oauthConsumerKeySecret">The oauth consumer key secret.</param>
+        /// <param name="accessToken">The access token.</param>
+        /// <param name="accessTokenSecret">The access token secret.</param>
         public FlickrClient(string oauthConsumerKey, string oauthConsumerKeySecret, string accessToken, string accessTokenSecret)
         {
             _oauthConsumerKey = oauthConsumerKey;
@@ -551,11 +568,13 @@ namespace Open.Flickr
             {
                 return new Uri(OAuthClient.CreateOAuthUrl(_apiServiceUri, _oauthConsumerKey, _oauthConsumerKeySecret, _accessToken, _accessTokenSecret, mode: mode, parameters: parameters));
             }
+            else
+            {
+                parameters.Add("api_key", _apiKey);
+                List<string> keys = parameters.Select(p => $"{p.Key}={p.Value}").ToList();
 
-            parameters.Add("api_key", _accessToken);
-            List<string> keys = parameters.Select(p => $"{p.Key}={p.Value}").ToList();
-
-            return new Uri($"{_apiServiceUri}?{string.Join("&", keys)}");
+                return new Uri($"{_apiServiceUri}?{string.Join("&", keys)}");
+            }
         }
 
         private static HttpClient CreateClient()

--- a/Open.Flickr/Photo.cs
+++ b/Open.Flickr/Photo.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Serialization;
+﻿using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
 
 namespace Open.Flickr
 {
@@ -34,6 +36,15 @@ namespace Open.Flickr
     {
         [DataMember(Name = "photo", IsRequired = false)]
         public Photo2 Photo { get; set; }
+        [DataMember(Name = "stat", IsRequired = false)]
+        public string Stat { get; set; }
+    }
+
+    public class PhotoSizeResult
+    {
+        [DataMember(Name = "sizes", IsRequired = false)]
+        public PhotoSizeCollection Sizes { get; set; }
+
         [DataMember(Name = "stat", IsRequired = false)]
         public string Stat { get; set; }
     }
@@ -230,8 +241,47 @@ namespace Open.Flickr
         public Number Comments { get; set; }
         [DataMember(Name = "visibility", IsRequired = false)]
         public Visibility Visibility { get; set; }
-        [DataMember(Name = "usage")]
+        [DataMember(Name = "usage", IsRequired = false)]
         public Usage Usage { get; set; }
+
+        // note that this seems to only ever have one item in it, so is a faux collection
+        [DataMember(Name = "urls", IsRequired = false)]
+        public Urls Urls { get; set; }
+    }
+
+    [DataContract]
+    public class PhotoSize
+    {
+        [DataMember(Name = "label")]
+        public string Label { get; set; }
+
+        [DataMember(Name = "width")]
+        public int Width { get; set; }
+
+        [DataMember(Name = "height")]
+        public int Height { get; set; }
+
+        [DataMember(Name = "source")]
+        public string Source { get; set; }
+
+        [DataMember(Name = "media")]
+        public string Media { get; set; }
+    }
+
+    [DataContract]
+    public class PhotoSizeCollection
+    {
+        [DataMember(Name = "canblog")]
+        public bool CanBlog { get; set; }
+
+        [DataMember(Name = "canprint")]
+        public bool CanPrint { get; set; }
+
+        [DataMember(Name = "candownload")]
+        public bool CanDownload { get; set; }
+
+        [DataMember(Name = "size")]
+        public List<PhotoSize> Sizes { get; set; }
     }
 
     [DataContract]
@@ -239,6 +289,22 @@ namespace Open.Flickr
     {
         [DataMember(Name = "_content", IsRequired = false)]
         public int Value { get; set; }
+    }
+
+    public class Url
+    {
+        [DataMember(Name = "type", IsRequired = false)]
+        public string Type { get; set; }
+
+        public string _content { get; set; }
+
+        public string Value => _content;
+    }
+
+    public class Urls
+    {
+        [DataMember(Name = "url", IsRequired = false)]
+        public List<Url> Url { get; set; }
     }
 
     [DataContract]


### PR DESCRIPTION
A few more fixes/tweaks based on our use case - mainly allowing it to run with a static api key and adding photo sizes, plus the urls element of photo getInfo.